### PR TITLE
Upgrade Go to 1.26.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/carto-run/fake-jenkins
 
-go 1.25.0
+go 1.26.5
 
 require (
 	github.com/goji/httpauth v0.0.0-20160601135302-2da839ab0f4d


### PR DESCRIPTION
## Summary

Upgrades the Go version directive in go.mod from 1.25.0 to 1.26.5 (latest stable release).

## Changes

- Bumped `go` directive in go.mod to 1.26.5
- Verified: `go build ./...` and `go test ./...` both pass
- go.sum remains unchanged (no further tidy changes)

## CI

CI workflows already track the Go version via `actions/setup-go` with `go-version-file: "go.mod"`, so no workflow changes are needed.

## Dependency evaluation

- **github.com/goji/httpauth**: Evaluated but intentionally left on its pseudo-version (v0.0.0-20160601135302-2da839ab0f4d). The upstream repository has been abandoned since 2016 and has never published any tagged releases, so no stable version exists to upgrade to.